### PR TITLE
fix: update github repo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "deep-email-validator",
+  "name": "lib-deep-email-validator",
   "version": "0.1.22",
   "files": [
     "dist/**/*"
@@ -9,7 +9,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mfbx9da4/deep-email-validator"
+    "url": "https://github.com/televisa-univision/lib-deep-email-validator"
   },
   "author": "David Alberto Adler",
   "license": "MIT",


### PR DESCRIPTION
Maybe it will fail by tokens

```shell
errors: [
    SemanticReleaseError: No GitHub token specified.
        at getError (file:///Users/roramirez/Documents/projects/lib-deep-email-validator/node_modules/@semantic-release/github/lib/get-error.js:7:10)
        at verify (file:///Users/roramirez/Documents/projects/lib-deep-email-validator/node_modules/@semantic-release/github/lib/verify.js:148:17)
        at verifyConditions (file:///Users/roramirez/Documents/projects/lib-deep-email-validator/node_modules/@semantic-release/github/index.js:51:9)
        at validator (file:///Users/roramirez/Documents/projects/lib-deep-email-validator/node_modules/semantic-release/lib/plugins/normalize.js:36:30)
        at file:///Users/roramirez/Documents/projects/lib-deep-email-validator/node_modules/semantic-release/lib/plugins/pipeline.js:38:42
        at next (file:///Users/roramirez/Documents/projects/lib-deep-email-validator/node_modules/p-reduce/index.js:16:10) {
      code: 'ENOGHTOKEN',
      details: 'A [GitHub personal token](https://github.com/semantic-release/github#readme/blob/master/README.md#github-authentication) must be created and set in the `GH_TOKEN` or `GITHUB_TOKEN` environment variable on your CI environment.\n' +
        '\n' +
        'Please make sure to create a [GitHub personal token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line) and to set it in the `GH_TOKEN` or `GITHUB_TOKEN` environment variable on your CI environment. The token must allow to push to the repository televisa-univision/lib-deep-email-validator.',
      semanticRelease: true,
      pluginName: '@semantic-release/github'
    }
  ]
``` 